### PR TITLE
Ingest Restructuring - Part 1

### DIFF
--- a/scripts/python/create_sample_ingest_file.py
+++ b/scripts/python/create_sample_ingest_file.py
@@ -1,0 +1,31 @@
+""" A tool to generate sample files for ingest.
+
+These files can be used to test algorithms with more
+realistic data.
+
+"""
+import argparse
+from astropy.time import Time
+
+
+def get_options(args=None):
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--num-of-files",
+        type=int,
+        default=1,
+        help="The number of ingest files to generate for testing."
+    )
+
+    parser.add_argument(
+        "--date-now",
+        default=Time.now(),
+        help="Set start time for the first file for testing (default=NOW)"
+    )
+
+    return parser.parse_args(args)
+
+
+def main():
+    pass


### PR DESCRIPTION
- Modified the ingest to use a dedicated processing file queue with chunking.
- Changed memory allocation based on ingest file meta data.
- Each ingest process now shares a global memory for ingest data.
- Attempt to sort ingest files by sort time prior to ingest.
- Boilerplate for script creating example ingest file. 